### PR TITLE
feat: Dashboard Layout

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 
 NEXT_PUBLIC_API_BASE_URL=https://flower.elevateegy.com
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
-
+NEXTAUTH_SECRET=FAF5D867C12D6519813A5DBE2C9B3 
 BASE_URL="https://flower.elevateegy.com/api/v1"
 

--- a/src/app/[locale]/(dashboard)/dashboard/category/page.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/category/page.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default function Page() {
+  return (
+    <div>category page</div>
+  )
+}

--- a/src/app/[locale]/(dashboard)/dashboard/error.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/error.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  // Translate
+  const t = useTranslations();
+
+  // UseEffect
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html>
+      <body
+        className={
+          ' flex flex-col items-center justify-center min-h-screen bg-zinc-900 text-white text-center p-6'
+        }
+      >
+        <h1 className='text-6xl font-bold text-soft-pink-400 mb-4'>
+          {t('error-title')}
+        </h1>
+
+        <p className='text-zinc-400 mb-6 max-w-md'>{t('error-description')}</p>
+
+        <div className='flex gap-4'>
+          <button
+            onClick={() => reset()}
+            className='px-6 py-3 bg-soft-pink-400 text-white rounded-full hover:bg-soft-pink-600 transition-colors'
+          >
+            {t('error-try-again-button')}
+          </button>
+
+          <Link
+            href='/'
+            className='px-6 py-3 bg-zinc-700 text-white rounded-full hover:bg-zinc-600 transition-colors'
+          >
+            {t('error-go-home-button')}
+          </Link>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/[locale]/(dashboard)/dashboard/layout.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/layout.tsx
@@ -1,0 +1,24 @@
+import { Header, Sidebar } from '@/components/layout/dashboard';
+import { cn } from '@/lib/utils/utils';
+import { getLocale } from 'next-intl/server';
+
+export default async function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // Locale
+  const locale = await getLocale();
+
+  // Variables
+  const RTL: boolean = locale === 'ar';
+  return (
+    <div>
+      <Sidebar />
+      <div className={cn('w-full', RTL ? 'pr-80' : 'pl-80')}>
+        <Header />
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/(dashboard)/dashboard/loading.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/loading.tsx
@@ -1,0 +1,13 @@
+import { Loader2Icon } from 'lucide-react';
+import React from 'react';
+
+export default function Loading() {
+  return (
+    <div className=' flex justify-center items-center w-full h-screen'>
+      <Loader2Icon
+        className='animate-spin text-maroon-600 dark:text-soft-pink-200'
+        size={80}
+      />
+    </div>
+  );
+}

--- a/src/app/[locale]/(dashboard)/dashboard/occasions/page.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/occasions/page.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Page() {
+  return <div> occasions page</div>;
+}

--- a/src/app/[locale]/(dashboard)/dashboard/overview/page.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/overview/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>overview page</div>;
+}

--- a/src/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default async function Page() {
+  redirect('dashboard/overview');
+}

--- a/src/app/[locale]/(dashboard)/dashboard/products/page.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/products/page.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Page() {
+  return <div>products page</div>;
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -41,15 +41,23 @@ export const authOptions: NextAuthOptions = {
   callbacks: {
     jwt: ({ token, user }) => {
       if (user) {
+        token.id = user._id;
         token.email = user.email;
+        token.firstName = user.firstName;
+        token.lastName = user.lastName;
+        token.gender = user.gender;
+        token.phone = user.phone;
+        token.photo = user.photo;
+        token.role = user.role;
         token.token = user.token;
       }
       return token;
     },
     session: ({ session, token }) => {
-      session._id = token._id;
+      session.id = token._id;
       session.email = token.email || '';
       session.role = token.role;
+      session.photo = token.photo;
       session.firstName = token.firstName;
       session.lastName = token.lastName;
       return session;

--- a/src/components/layout/dashboard/constants/navigate-links.constant.tsx
+++ b/src/components/layout/dashboard/constants/navigate-links.constant.tsx
@@ -1,0 +1,33 @@
+import {
+  CalendarHeart,
+  ClipboardList,
+  LayoutDashboard,
+  Package,
+} from 'lucide-react';
+
+export const NAVIGATE_LINKS = [
+  {
+    icon: LayoutDashboard,
+    label: 'Overview',
+    hrf: '/dashboard/overview',
+    ar: 'الملخص',
+  },
+  {
+    icon: ClipboardList,
+    label: 'Categories',
+    hrf: '/dashboard/category',
+    ar: 'الفئات',
+  },
+  {
+    icon: CalendarHeart,
+    label: 'Occasions',
+    hrf: '/dashboard/occasions',
+    ar: 'المناسبات',
+  },
+  {
+    icon: Package,
+    label: 'Products',
+    hrf: '/dashboard/products',
+    ar: 'المنتجات',
+  },
+] as const;

--- a/src/components/layout/dashboard/header.tsx
+++ b/src/components/layout/dashboard/header.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import { Link } from '@/i18n/navigation';
+import { useLocale, useTranslations } from 'next-intl';
+import { usePathname } from 'next/navigation';
+import React from 'react';
+
+export default function Header() {
+  // Translate
+  const t = useTranslations()
+
+  // Pathname
+  const pathname = usePathname();
+
+  // Variables
+  // /en/dashboard/products => ["dashboard", "products"]
+  const segments = pathname.split('/').filter(Boolean).slice(1);
+  
+  const labelMap: Record<string, string> = {
+    dashboard: t("dashboard-header-breadcrumb-link-1"),
+    overview: t("dashboard-header-breadcrumb-link-2"),
+    category: t("dashboard-header-breadcrumb-link-3"),
+    occasions: t("dashboard-header-breadcrumb-link-4"),
+    products: t("dashboard-header-breadcrumb-link-5"),
+  };
+  
+    // Function
+    function buildHref(index: number) {
+      const path = ['/', ...segments.slice(0, index + 1)].join('/');
+      return path;
+    }
+  return (
+    <header className='px-4 py-6 border-b border-b-black/10 dark:border-b-white/30'>
+      <Breadcrumb>
+        <BreadcrumbList>
+          {segments.map((segment, index) => (
+            <React.Fragment key={segment}>
+              {index !== 0 && <BreadcrumbSeparator />}
+
+              <BreadcrumbItem>
+                <BreadcrumbLink asChild>
+                  <Link href={buildHref(index)} className='capitalize'>
+                    {labelMap[segment] ?? segment}
+                  </Link>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+            </React.Fragment>
+          ))}
+        </BreadcrumbList>
+      </Breadcrumb>
+    </header>
+  );
+}

--- a/src/components/layout/dashboard/index.ts
+++ b/src/components/layout/dashboard/index.ts
@@ -1,0 +1,2 @@
+export { default as Header } from './header';
+export { default as Sidebar } from './sidebar/sidebar';

--- a/src/components/layout/dashboard/sidebar/admin.tsx
+++ b/src/components/layout/dashboard/sidebar/admin.tsx
@@ -26,7 +26,7 @@ export default function Admin() {
   const firstName = session.data?.firstName ?? 'A';
   const avatarBg = randomColor(firstName);
   const firstLetter = firstName.charAt(0).toUpperCase();
-  const hasImage = session.data?.image && session.data.image !== '';
+  const hasImage = session.data?.photo && session.data.photo !== '';
   const RTL: boolean = locale === 'ar';
 
   return (
@@ -36,7 +36,7 @@ export default function Admin() {
         <div className='flex justify-center items-center rounded-full overflow-hidden w-12 h-12'>
           {hasImage ? (
             <Image
-              src={session.data?.image === undefined && '/assets/logo1.svg'}
+              src={session.data?.photo}
               alt={firstName}
               width={54}
               height={54}
@@ -71,7 +71,7 @@ export default function Admin() {
         <div
           className={cn(
             ' absolute bottom-0  w-56 rounded-xl font-inter bg-white dark:bg-zinc-700 border border-zinc-100',
-            RTL ? '-left-56' : '-right-56'
+            RTL ? '-left-60' : '-right-60'
           )}
         >
           {/* Header */}
@@ -84,6 +84,7 @@ export default function Admin() {
           <Link
             href={'/account'}
             className=' flex justify-start items-center gap-2 font-medium capitalize p-2 hover:bg-zinc-200 dark:hover:bg-zinc-500 border-b-zinc-100 border-b'
+            onClick={() => setToggle(false)}
           >
             <User size={16} />
             {t('dashboard-sidebar-admin-menu-action-link-1')}
@@ -91,7 +92,10 @@ export default function Admin() {
 
           <div
             className=' flex justify-start items-center gap-2 font-medium capitalize p-2 cursor-pointer hover:bg-maroon-300 border-b-zinc-100 border-b rounded-b-xl'
-            onClick={() => signOut()}
+            onClick={() => {
+              signOut();
+              setToggle(false);
+            }}
           >
             <LogOut size={16} />
             <p>{t('dashboard-sidebar-admin-menu-action-link-2')}</p>

--- a/src/components/layout/dashboard/sidebar/admin.tsx
+++ b/src/components/layout/dashboard/sidebar/admin.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { Link } from '@/i18n/navigation';
+import { randomColor } from '@/lib/utils/random-color';
+import { cn } from '@/lib/utils/utils';
+import { EllipsisVertical, LogOut, User } from 'lucide-react';
+import { signOut, useSession } from 'next-auth/react';
+import { useLocale, useTranslations } from 'next-intl';
+import Image from 'next/image';
+import { useState } from 'react';
+
+export default function Admin() {
+  // Translate
+  const t = useTranslations();
+
+  // Session
+  const session = useSession();
+
+  // Locale
+  const locale = useLocale();
+
+  // State
+  const [toggle, setToggle] = useState<boolean>(false);
+
+  // Variables
+  const firstName = session.data?.firstName ?? 'A';
+  const avatarBg = randomColor(firstName);
+  const firstLetter = firstName.charAt(0).toUpperCase();
+  const hasImage = session.data?.image && session.data.image !== '';
+  const RTL: boolean = locale === 'ar';
+
+  return (
+    <div className=' relative flex justify-center items-end gap-5 border-t border-t-black/10 mx-6 mt-80'>
+      <div className=' flex justify-center items-end gap-2.5'>
+        {/* Avatar */}
+        <div className='flex justify-center items-center rounded-full overflow-hidden w-12 h-12'>
+          {hasImage ? (
+            <Image
+              src={session.data?.image === undefined && '/assets/logo1.svg'}
+              alt={firstName}
+              width={54}
+              height={54}
+              className='object-cover'
+            />
+          ) : (
+            <div
+              className='w-11 h-11 flex justify-center items-center text-white font-bold text-xl rounded-full'
+              style={{ backgroundColor: avatarBg }}
+            >
+              <p>{firstLetter}</p>
+            </div>
+          )}
+        </div>
+
+        {/* Admin Information */}
+        <div>
+          <h3 className=' font-bold'>{`${session.data?.firstName} ${session.data?.lastName}`}</h3>
+          <p className=' font-semibold text-zinc-300 text-xs'>
+            {session.data?.email}
+          </p>
+        </div>
+      </div>
+
+      {/* Menu */}
+      <div className=' p-1 cursor-pointer' onClick={() => setToggle(!toggle)}>
+        <EllipsisVertical size={18} />
+      </div>
+
+      {/* Menu Action */}
+      {toggle && (
+        <div
+          className={cn(
+            ' absolute bottom-0  w-56 rounded-xl font-inter bg-white dark:bg-zinc-700 border border-zinc-100',
+            RTL ? '-left-56' : '-right-56'
+          )}
+        >
+          {/* Header */}
+          <h3 className=' capitalize font-semibold text-maroon-600 dark:text-soft-pink-200 pl-4 p-2 border-b-zinc-100 border-b'>
+            {`${session.data?.firstName} ${session.data?.lastName}`}
+          </h3>
+
+          {/* Buttons */}
+
+          <Link
+            href={'/account'}
+            className=' flex justify-start items-center gap-2 font-medium capitalize p-2 hover:bg-zinc-200 dark:hover:bg-zinc-500 border-b-zinc-100 border-b'
+          >
+            <User size={16} />
+            {t('dashboard-sidebar-admin-menu-action-link-1')}
+          </Link>
+
+          <div
+            className=' flex justify-start items-center gap-2 font-medium capitalize p-2 cursor-pointer hover:bg-maroon-300 border-b-zinc-100 border-b rounded-b-xl'
+            onClick={() => signOut()}
+          >
+            <LogOut size={16} />
+            <p>{t('dashboard-sidebar-admin-menu-action-link-2')}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/dashboard/sidebar/navigate.tsx
+++ b/src/components/layout/dashboard/sidebar/navigate.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Link, usePathname } from '@/i18n/navigation';
+import { NAVIGATE_LINKS } from '../constants/navigate-links.constant';
+import { useLocale } from 'next-intl';
+import { cn } from '@/lib/utils/utils';
+
+export default function Navigate() {
+  // Pathname
+  const pathname = usePathname();
+
+  // Locale
+  const locale = useLocale();
+
+  // Variables
+  const Lang = locale === 'ar' ? 'ar' : 'label';
+  return (
+    <div className=' flex flex-col gap-4 font-bold w-full'>
+      {NAVIGATE_LINKS.map(link => (
+        <Link
+          href={link.hrf}
+          key={link.hrf}
+          className={cn(
+            ' capitalize flex gap-2.5 p-2.5 w-full',
+            pathname === link.hrf &&
+              ' bg-maroon-50 text-maroon-600 rounded-xl w-full'
+          )}
+        >
+          <link.icon
+            className={cn(pathname === `/${link.hrf}` && 'text-Maroon-600')}
+            size={25}
+          />
+          {link[Lang]}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/src/components/layout/dashboard/sidebar/sidebar.tsx
+++ b/src/components/layout/dashboard/sidebar/sidebar.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import Image from 'next/image';
+import { Button } from '@/components/ui/button';
+import { Flower } from 'lucide-react';
+import Navigate from './navigate';
+import { Link } from '@/i18n/navigation';
+import Admin from './admin';
+import { useTranslations } from 'next-intl';
+import { SessionProvider } from 'next-auth/react';
+
+export default function Sidebar() {
+  // Translate
+  const t = useTranslations();
+  return (
+    <aside className='fixed bg-white dark:bg-zinc-700 border-r w-80 border-r-black/10 dark:border-r-white/20 p-6 h-screen'>
+      <div className=' flex flex-col items-baseline  gap-6 px-8'>
+        {/* Logo */}
+        <div className='flex justify-center items-center w-full'>
+          <Image
+            src='/assets/logo1.svg'
+            alt={t('dashboard-sidebar-image-alt')}
+            width={120}
+            height={112}
+            className='object-cover'
+            loading='lazy'
+          />
+        </div>
+
+        {/* Preview */}
+        <Link href={'/'} className=' w-full font-inter'>
+          <Button className=' gap-2 w-full'>
+            <Flower />
+            {t('dashboard-sidebar-button-preview')}
+          </Button>
+        </Link>
+
+        {/* Links */}
+        <Navigate />
+      </div>
+
+      {/* Admin */}
+      <SessionProvider>
+        <Admin />
+      </SessionProvider>
+    </aside>
+  );
+}

--- a/src/components/providers/index.tsx
+++ b/src/components/providers/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Toaster } from '../../components/ui/sonner';
 import { QueryProvider } from './query-provider';
 import { ThemeProvider } from './theme-provider';
+import { SessionProvider } from 'next-auth/react';
 
 export default function Providers({
   children,

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,115 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { ChevronRight, MoreHorizontal } from "lucide-react"
+
+import { cn } from "@/lib/utils/utils"
+
+const Breadcrumb = React.forwardRef<
+  HTMLElement,
+  React.ComponentPropsWithoutRef<"nav"> & {
+    separator?: React.ReactNode
+  }
+>(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />)
+Breadcrumb.displayName = "Breadcrumb"
+
+const BreadcrumbList = React.forwardRef<
+  HTMLOListElement,
+  React.ComponentPropsWithoutRef<"ol">
+>(({ className, ...props }, ref) => (
+  <ol
+    ref={ref}
+    className={cn(
+      "flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5",
+      className
+    )}
+    {...props}
+  />
+))
+BreadcrumbList.displayName = "BreadcrumbList"
+
+const BreadcrumbItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentPropsWithoutRef<"li">
+>(({ className, ...props }, ref) => (
+  <li
+    ref={ref}
+    className={cn("inline-flex items-center gap-1.5", className)}
+    {...props}
+  />
+))
+BreadcrumbItem.displayName = "BreadcrumbItem"
+
+const BreadcrumbLink = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentPropsWithoutRef<"a"> & {
+    asChild?: boolean
+  }
+>(({ asChild, className, ...props }, ref) => {
+  const Comp = asChild ? Slot : "a"
+
+  return (
+    <Comp
+      ref={ref}
+      className={cn("transition-colors hover:text-foreground", className)}
+      {...props}
+    />
+  )
+})
+BreadcrumbLink.displayName = "BreadcrumbLink"
+
+const BreadcrumbPage = React.forwardRef<
+  HTMLSpanElement,
+  React.ComponentPropsWithoutRef<"span">
+>(({ className, ...props }, ref) => (
+  <span
+    ref={ref}
+    role="link"
+    aria-disabled="true"
+    aria-current="page"
+    className={cn("font-normal text-foreground", className)}
+    {...props}
+  />
+))
+BreadcrumbPage.displayName = "BreadcrumbPage"
+
+const BreadcrumbSeparator = ({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) => (
+  <li
+    role="presentation"
+    aria-hidden="true"
+    className={cn("[&>svg]:w-3.5 [&>svg]:h-3.5", className)}
+    {...props}
+  >
+    {children ?? <ChevronRight />}
+  </li>
+)
+BreadcrumbSeparator.displayName = "BreadcrumbSeparator"
+
+const BreadcrumbEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<"span">) => (
+  <span
+    role="presentation"
+    aria-hidden="true"
+    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    {...props}
+  >
+    <MoreHorizontal className="h-4 w-4" />
+    <span className="sr-only">More</span>
+  </span>
+)
+BreadcrumbEllipsis.displayName = "BreadcrumbElipssis"
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -101,5 +101,17 @@
   "footer-discover": "تعرّف على موقعنا الإلكتروني",
   "footer-title": " احصل على كوبون خصم بنسبة <span>20%</span>",
   "footer-subtitle": "من خلال الاشتراك في نشرتنا الإخبارية",
-  "footer-subscribe-button": "اشترك الان"
+  "footer-subscribe-button": "اشترك الان",
+  
+  "dashboard-header-breadcrumb-link-1": "لوحه الاعدادات",
+  "dashboard-header-breadcrumb-link-2": "الملخص",
+  "dashboard-header-breadcrumb-link-3": "الفئات",
+  "dashboard-header-breadcrumb-link-4": "المناسبات",
+  "dashboard-header-breadcrumb-link-5": "المنتجات",
+
+  "dashboard-sidebar-image-alt": "صوره روز",
+  "dashboard-sidebar-button-preview": "معاينة الموقع",
+
+  "dashboard-sidebar-admin-menu-action-link-1": "اعدادات الحساب",
+  "dashboard-sidebar-admin-menu-action-link-2": "تسجيل الخروج"
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -106,5 +106,18 @@
   "footer-discover": "Discover our website",
   "footer-title": "Get <span>20% </span> Off Discount Coupon",
   "footer-subtitle": "By subscribing to our newsletter",
-  "footer-subscribe-button": "Subscribe"
+  "footer-subscribe-button": "Subscribe",
+
+  "dashboard-header-breadcrumb-link-1": "dashboard",
+  "dashboard-header-breadcrumb-link-2": "overview",
+  "dashboard-header-breadcrumb-link-3": "category",
+  "dashboard-header-breadcrumb-link-4": "occasions",
+  "dashboard-header-breadcrumb-link-5": "products",
+
+  "dashboard-sidebar-image-alt": "Rose Logo",
+  "dashboard-sidebar-button-preview": "Preview website",
+  
+  "dashboard-sidebar-admin-menu-action-link-1": "account",
+  "dashboard-sidebar-admin-menu-action-link-2": "log out"
+
 }

--- a/src/lib/types/next-auth.d.ts
+++ b/src/lib/types/next-auth.d.ts
@@ -12,6 +12,7 @@ declare module 'next-auth' {
     email: string;
     gender: string;
     phone: string;
+    photo: string;
     role: string;
     token: string;
   }

--- a/src/lib/utils/random-color.ts
+++ b/src/lib/utils/random-color.ts
@@ -1,0 +1,10 @@
+export function randomColor(str: string) {
+  let hash = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+
+  const color = `hsl(${hash % 360}, 70%, 50%)`;
+  return color;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,30 +1,39 @@
-import createMiddleware from 'next-intl/middleware';
 import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import createMiddleware from 'next-intl/middleware';
 import { routing } from './i18n/routing';
 
-// Variables
-const privatePages = ['/wishlist'];
 const handleI18nRouting = createMiddleware(routing);
 
-// Functions
-export default function middleware(req: NextRequest) {
-  const publicPathnameRegex = RegExp(
-    `^(/(${routing.locales.join('|')}))?(${privatePages
-      .flatMap(p => (p === '/' ? ['', '/'] : p))
-      .join('|')})/?$`,
-    'i'
-  );
-  const isPublicPage = publicPathnameRegex.test(req.nextUrl.pathname);
+export async function middleware(req: NextRequest) {
+  const { nextUrl } = req;
 
-  if (isPublicPage) {
-    return NextResponse.redirect(new URL('/login', req.nextUrl.origin));
-  } else {
-    return handleI18nRouting(req);
+  // Remove locale prefix (/en, /ar)
+  const pathname = nextUrl.pathname.replace(/^\/(en|ar)/, '');
+
+  // Check if route starts with /dashboard
+  const isDashboardRoute = pathname.startsWith('/dashboard');
+
+  // Get session (NextAuth v4)
+  const token = await getToken({
+    req,
+    secret: process.env.NEXTAUTH_SECRET,
+  });
+
+  // UNAUTHENTICATED -> redirect home
+  if (isDashboardRoute && !token) {
+    return NextResponse.redirect(new URL('/', req.url));
   }
+
+  // AUTHENTICATED but NOT ADMIN → redirect home
+  if (isDashboardRoute && token?.role !== 'admin') {
+    return NextResponse.redirect(new URL('/', req.url));
+  }
+
+  // Continue with intl routing
+  return handleI18nRouting(req);
 }
 
-// Configuration matcher
 export const config = {
-  // Match only internationalized pathnames
-  matcher: '/((?!api|trpc|_next|_vercel|.*\\..*).*)',
+  matcher: ['/((?!api|_next|_vercel|.*\\..*).*)'],
 };


### PR DESCRIPTION
This pull request adds to create a dashboard layout for issue #40, including Update the middleware, Create all dashboard pages, create loading page and create global error page.

# Key Features: 
* Create a separate Dashboard route that only admins can access.
* Implement a list if Navigation Links in the sidebar, and add a Preview Website link to navigate user to the main website.
* Display the Account Details and display a dropdown when clicking the user details dots.
* User details must contain the user’s image, in case it doesn’t has an image, display the first letter of the user’s name with unique background.
* Implement a Children Container with the Dashboard title h3.

